### PR TITLE
refactor: reduce landing scraper chunk size

### DIFF
--- a/src/scraper/src/fiskedir/landings.rs
+++ b/src/scraper/src/fiskedir/landings.rs
@@ -38,7 +38,7 @@ impl DataSource for LandingScraper {
                     FileHash::Landings,
                     source,
                     closure,
-                    100000,
+                    10000,
                 )
                 .await
             {


### PR DESCRIPTION
Seems like we're running OOM in our aks cluster.