### PR TITLE
refactor: add statistics entry to speedup trips_detailed query

### DIFF
--- a/src/postgres/migrations/20230818154929_landing_gear_group_ids_statistics.sql
+++ b/src/postgres/migrations/20230818154929_landing_gear_group_ids_statistics.sql
@@ -1,0 +1,4 @@
+CREATE STATISTICS start_gear_groups (mcv) ON start_timestamp,
+landing_gear_group_ids
+FROM
+    trips_detailed td;


### PR DESCRIPTION
The trips endpoint becomes slow as the postgres planner assumes that its going to be faster to scan the `start_timestamp`
index (for the order by clause) and find the amount of rows matching the where condition rather than using the existing `landing_gear_group_ids` index.
This is true for all gear_group_ids except `Ukjent` and `Oppdrett`, this leads to slow queries for these cases if no other filters are specified or a larger limit value is specified.

To fix this we add a MVC statistic to the combination of `start_timestamp` and `gear_group_ids`, this is only relevant for the
case where we order by start_timestamp, however, from local testing it seems that the planner is able to change its mind
after seeing a query using the `gear_group_ids` index and subsequent queries (even ones ordering by `stop_timestamp` or weight) will use the `gear_group_ids` index.