### PR TITLE
refactor: increase statistics gathererd for landing_gear_ids

### DIFF
--- a/src/postgres/migrations/20230818164345_landing_gear_group_ids_statistics_increase.sql
+++ b/src/postgres/migrations/20230818164345_landing_gear_group_ids_statistics_increase.sql
@@ -1,0 +1,4 @@
+ALTER TABLE trips_detailed
+ALTER COLUMN landing_gear_group_ids
+SET
+    STATISTICS 1000;


### PR DESCRIPTION
We are now only seeing the planner picking a sub-optimal plan when both `Ukjent` and `Oppdrett` is specified.
Increasing the statistics gathered for the relevant column in hopes of resolving this. Cannot reproduce this situation locally as of now.