### PR TITLE
fix: handle landing assembler conflicts on same day

### DIFF
--- a/src/postgres/migrations/20231030135916_queue_trip_reset.sql
+++ b/src/postgres/migrations/20231030135916_queue_trip_reset.sql
@@ -1,0 +1,5 @@
+UPDATE trip_calculation_timers
+SET
+    queued_reset = TRUE
+WHERE
+    trip_assembler_id = 1;

--- a/src/postgres/src/queries/landing.rs
+++ b/src/postgres/src/queries/landing.rs
@@ -1,5 +1,6 @@
 use bigdecimal::{BigDecimal, ToPrimitive};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
+use chrono::{NaiveDateTime, NaiveTime};
 use futures::Stream;
 use futures::TryStreamExt;
 use kyogre_core::TripAssemblerId;
@@ -338,7 +339,10 @@ RETURNING
                     .and_modify(|v| v.timestamp = min(v.timestamp, i.landing_timestamp))
                     .or_insert_with(|| TripAssemblerConflict {
                         fiskeridir_vessel_id: id,
-                        timestamp: i.landing_timestamp,
+                        timestamp: Utc.from_utc_datetime(&NaiveDateTime::new(
+                            i.landing_timestamp.date_naive(),
+                            NaiveTime::from_hms_opt(0, 0, 0).unwrap(),
+                        )),
                     });
                 vessel_event_ids.push(event_id);
             }


### PR DESCRIPTION
We now create the conflict on the start of the day to ensure that we fetch the correct prior trip in the assembler.
