### PR TITLE
fix: prune dirty dates on clean local deployment

### DIFF
--- a/src/.sqlx/query-f8767467de2ac1203d01ca0710b6b0201e6df5034d6b152471abf183102d46fb.json
+++ b/src/.sqlx/query-f8767467de2ac1203d01ca0710b6b0201e6df5034d6b152471abf183102d46fb.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\nDELETE FROM daily_weather_dirty\nWHERE\n    date NOT IN (\n        SELECT DISTINCT\n            timestamp::date\n        FROM\n            weather\n    )\n             ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "f8767467de2ac1203d01ca0710b6b0201e6df5034d6b152471abf183102d46fb"
+}

--- a/src/engine/src/states/daily_weather.rs
+++ b/src/engine/src/states/daily_weather.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use async_trait::async_trait;
 use machine::Schedule;
+use orca_core::Environment;
 use tracing::{event, Level};
 
 pub struct DailyWeatherState;
@@ -10,6 +11,23 @@ impl machine::State for DailyWeatherState {
     type SharedState = SharedState;
 
     async fn run(&self, shared_state: Self::SharedState) -> Self::SharedState {
+        let environment: Environment = std::env::var("APP_ENVIRONMENT")
+            .unwrap()
+            .try_into()
+            .expect("failed to parse APP_ENVIRONMENT");
+
+        // On a fresh Local deployment it takes too long to perform the initial DailyWeather,
+        // so prune the dirty table to only dates with weather.
+        if environment == Environment::Local {
+            if let Err(e) = shared_state
+                .catch_location_weather
+                .prune_dirty_dates()
+                .await
+            {
+                event!(Level::ERROR, "failed to prune dirty weather dates: {:?}", e);
+            }
+        }
+
         match shared_state
             .catch_location_weather
             .catch_locations_with_weather()
@@ -18,7 +36,7 @@ impl machine::State for DailyWeatherState {
             Err(e) => {
                 event!(
                     Level::ERROR,
-                    "failed to fetch  catch location with weather: {:?}",
+                    "failed to fetch catch location with weather: {:?}",
                     e
                 );
             }

--- a/src/kyogre-core/src/ports/inbound.rs
+++ b/src/kyogre-core/src/ports/inbound.rs
@@ -171,6 +171,7 @@ pub trait HaulWeatherInbound: Send + Sync {
 pub trait DailyWeatherInbound: Send + Sync {
     async fn catch_locations_with_weather(&self) -> Result<Vec<CatchLocationId>, QueryError>;
     async fn dirty_dates(&self) -> Result<Vec<NaiveDate>, QueryError>;
+    async fn prune_dirty_dates(&self) -> Result<(), UpdateError>;
     async fn update_daily_weather(
         &self,
         catch_locations: &[CatchLocationId],

--- a/src/postgres/src/adapter.rs
+++ b/src/postgres/src/adapter.rs
@@ -390,6 +390,9 @@ impl DailyWeatherInbound for PostgresAdapter {
     async fn dirty_dates(&self) -> Result<Vec<NaiveDate>, QueryError> {
         Ok(self.dirty_dates_impl().await?)
     }
+    async fn prune_dirty_dates(&self) -> Result<(), UpdateError> {
+        Ok(self.prune_dirty_dates_impl().await?)
+    }
     async fn catch_locations_with_weather(&self) -> Result<Vec<CatchLocationId>, QueryError> {
         Ok(self.catch_locations_with_weather_impl().await?)
     }

--- a/src/postgres/src/queries/weather.rs
+++ b/src/postgres/src/queries/weather.rs
@@ -302,6 +302,25 @@ WHERE
         Ok(())
     }
 
+    pub(crate) async fn prune_dirty_dates_impl(&self) -> Result<(), PostgresErrorWrapper> {
+        sqlx::query!(
+            r#"
+DELETE FROM daily_weather_dirty
+WHERE
+    date NOT IN (
+        SELECT DISTINCT
+            timestamp::date
+        FROM
+            weather
+    )
+             "#
+        )
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+
     pub(crate) async fn dirty_dates_impl(&self) -> Result<Vec<NaiveDate>, PostgresErrorWrapper> {
         Ok(sqlx::query!(
             r#"


### PR DESCRIPTION
On a fresh Local deployment it takes too long to perform the initial DailyWeather,
so prune the dirty table to only dates with weather.