### PR TITLE
fix: make ais partitions play nicely with pg_restore

### DIFF
--- a/src/postgres/migrations/20250310130727_add_schema_to_ais_partition_creation.sql
+++ b/src/postgres/migrations/20250310130727_add_schema_to_ais_partition_creation.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION public.add_ais_position_partition () RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+        IF (TG_OP = 'INSERT') THEN
+            EXECUTE FORMAT(
+                $f$
+                    CREATE TABLE IF NOT EXISTS public.%I PARTITION OF public.ais_positions FOR VALUES IN (%L);
+                $f$,
+                CONCAT('ais_positions_', NEW.mmsi),
+                NEW.mmsi
+            );
+        END IF;
+
+        RETURN NEW;
+   END;
+$$;


### PR DESCRIPTION
When pg_restoring the ais_vessels table we currently fail because our trigger function does not specify which schema the partition should be created in.